### PR TITLE
Test AdMob ID used

### DIFF
--- a/app/src/main/java/com/followapp/mytasks/common/utils/Constants.kt
+++ b/app/src/main/java/com/followapp/mytasks/common/utils/Constants.kt
@@ -1,7 +1,7 @@
 package com.followapp.mytasks.common.utils
 
 object Constants {
-//        const val AD_ID = "ca-app-pub-3940256099942544/9214589741"  // Test AdMob ID, also in string.xml
-    const val AD_ID = "ca-app-pub-5163472824682213/1226263826"  //  Real Banner AdMob ID, also in string.xml
+    const val AD_ID = "ca-app-pub-3940256099942544/9214589741"  // Test AdMob ID, also in string.xml
+    //    const val AD_ID = "ca-app-pub-5163472824682213/1226263826"  //  Real Banner AdMob ID, also in string.xml
     const val WEB_CLIENT_ID = "692558155479-800k03813n3hand9nljrlnrtdnl4sens.apps.googleusercontent.com"
 }

--- a/app/src/main/java/com/followapp/mytasks/mainModule/view/MainActivity.kt
+++ b/app/src/main/java/com/followapp/mytasks/mainModule/view/MainActivity.kt
@@ -14,9 +14,9 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         initToolBar()
-//        launchHome()
+        launchHome()
         loadAdFragment()
-        loadLoginFragment()
+//        loadLoginFragment()
     }
 
     private fun launchHome() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,10 +20,10 @@
     <string name="action_toggle_group">Group done tasks</string>
 
 <!--    https://console.firebase.google.com/u/0/project/followapp-mytasks/authentication/providers?utm_source=studio-->
-     <string name="ad_unit_id">ca-app-pub-5163472824682213~4420222935</string>  <!--- FollowApp MyTasks ID -->
-<!--    <string name="ad_unit_id">ca-app-pub-3940256099942544~3347511713</string>  Banner test ID -->
-    <!-- <string name="ad_id">ca-app-pub-3940256099942544/9214589741</string>  Test AdMob ID, also in Constants -->
-     <string name="ad_id">ca-app-pub-5163472824682213/1226263826</string>   <!--Real Banner AdMob ID, also in Constants -->
+     <string name="ad_unit_id">ca-app-pub-5163472824682213~4420222935</string> <!---  FollowApp MyTasks ID -->
+    <!--  <string name="ad_unit_id">ca-app-pub-3940256099942544~3347511713</string>   Banner test ID -->
+  <string name="ad_id">ca-app-pub-3940256099942544/9214589741</string>     <!--Test AdMob ID, also in Constants -->
+    <!--<string name="ad_id">ca-app-pub-5163472824682213/1226263826</string>   Real Banner AdMob ID, also in Constants -->
 
     <string name="navigation_drawer_close">close</string>
     <string name="logout">Logout</string>


### PR DESCRIPTION
Instead of real AdMob IDs and login, now I just use test id during the developing process. Apparently real ids are not meant to be used during this process